### PR TITLE
Search with key which may not always exist

### DIFF
--- a/fuzzysort.js
+++ b/fuzzysort.js
@@ -74,7 +74,7 @@ USAGE:
                 if(targetPrepared !== undefined) target = targetPrepared
                 else preparedCache.set(target, target = fuzzysort.prepareFast(target))
               }
-            if(target._targetLowerCodes.length === 0) { objResults[keyI] = null; continue }
+            if(target._targetLowerCodes === undefined || target._targetLowerCodes === null || target._targetLowerCodes.length === 0) { objResults[keyI] = null; continue }
 
             objResults[keyI] = fuzzysort.algorithm(search, target, searchLowerCode)
           }
@@ -102,7 +102,7 @@ USAGE:
               if(targetPrepared !== undefined) target = targetPrepared
               else preparedCache.set(target, target = fuzzysort.prepareFast(target))
             }
-          if(target._targetLowerCodes.length === 0) continue
+          if(target._targetLowerCodes === undefined || target._targetLowerCodes === null || target._targetLowerCodes.length === 0) {continue }            
 
           var result = fuzzysort.algorithm(search, target, searchLowerCode)
           if(result === null) continue
@@ -124,7 +124,7 @@ USAGE:
               if(targetPrepared !== undefined) target = targetPrepared
               else preparedCache.set(target, target = fuzzysort.prepareFast(target))
             }
-          if(target._targetLowerCodes.length === 0) continue
+          if(target._targetLowerCodes === undefined || target._targetLowerCodes === null || target._targetLowerCodes.length === 0) { continue }          
 
           var result = fuzzysort.algorithm(search, target, searchLowerCode)
           if(result === null) continue


### PR DESCRIPTION
If search must happen using a search key coming from an array, if the arrays vary length in-between searched objects, the search will fail with an error, since one of the search keys may be null. 

For instance:
{
dyn_array: [
  { key1: "key1", key2: "key2"}, 
  { key1: "key1"}, 
  { key1: "key1", key2: "key2"}]
}
If the search uses the key dyn_array.1.key2, search preparation/search algorithm will fail because of key2 missing from the second object.

This PR is to prevent such kind of bugs from happening if a key used for search is missing (null or undefined). 