### PR TITLE
Stringify target before preparing

### DIFF
--- a/fuzzysort.js
+++ b/fuzzysort.js
@@ -67,6 +67,7 @@ USAGE:
           for (var keyI = keysLen - 1; keyI >= 0; --keyI) {
             var key = keys[keyI]
             var target = getValue(obj, key)
+            if(typeof target !== 'string' && target !== null && target !== undefined) target = target.toString()
             if(!target) { objResults[keyI] = null; continue }
             if(!isObj(target)) target = fuzzysort.getPrepared(target)
 
@@ -89,6 +90,7 @@ USAGE:
         var key = options.key
         for(var i = targetsLen - 1; i >= 0; --i) { var obj = targets[i]
           var target = getValue(obj, key)
+          if(typeof target !== 'string' && target !== null && target !== undefined) target = target.toString()
           if(!target) continue
           if(!isObj(target)) target = fuzzysort.getPrepared(target)
 


### PR DESCRIPTION
I had some usecases where entries to search in where arrays and not strings. This PR uses `target.toString()` in case it is not already a string. 

This allows us to search through array values and also leads to better handling of integers or booleans.