### PR TITLE
Fix bug where iCurrent wasn't being decremented when it defers

### DIFF
--- a/fuzzysort.js
+++ b/fuzzysort.js
@@ -181,6 +181,7 @@ USAGE:
 
               if(iCurrent%1000/*itemsPerCheck*/ === 0) {
                 if(Date.now() - startMs >= 10/*asyncInterval*/) {
+                  iCurrent-- // if we don't decrement here, step will continue with same value
                   isNode?setImmediate(step):setTimeout(step)
                   return
                 }
@@ -210,6 +211,7 @@ USAGE:
 
               if(iCurrent%1000/*itemsPerCheck*/ === 0) {
                 if(Date.now() - startMs >= 10/*asyncInterval*/) {
+                  iCurrent-- // if we don't decrement here, step will continue with same value
                   isNode?setImmediate(step):setTimeout(step)
                   return
                 }
@@ -233,6 +235,7 @@ USAGE:
 
               if(iCurrent%1000/*itemsPerCheck*/ === 0) {
                 if(Date.now() - startMs >= 10/*asyncInterval*/) {
+                  iCurrent-- // if we don't decrement here, step will continue with same value
                   isNode?setImmediate(step):setTimeout(step)
                   return
                 }


### PR DESCRIPTION
The bug can be quickly replicated like so:
```javascript
(() => {
 let tries = 3; let current = 10;
 function step() {
  for (; current >= 0; --current) {
   console.log(current);
   if (current % 7 === 0 && tries > 0) {
    tries -= 1; setTimeout(step); return;
   }
  }
 }
 step();
})()
```
This prints out 10,9,8,7,7,7,7,6,5,4,3,2,1.
The intended print is 10,9,8,7,6,5,4,3,2,1,0.

The decrement expression in the for loop (`--current`) only executes when the `for` reaches the end of a single loop. So in our case, it cannot execute, because we are `return`ing.

The fix is very simple, if we directly decrement `current` before calling `setTimeout`, the function works as intended.

```javascript
(() => {
 let tries = 3; let current = 10;
 function step() {
  for (; current >= 0; --current) {
   console.log(current);
   if (current % 7 === 0 && tries > 0) {
    tries -= 1; --current; setTimeout(step); return;
   }
  }
 }
 step();
})()
```

The effect of the bug is duplicate results when a 1000 element pass takes more than 10ms.