### PR TITLE
fixes #69 (crash on empty value in prepared field key:ed by Symbol); …

### DIFF
--- a/fuzzysort.js
+++ b/fuzzysort.js
@@ -575,7 +575,7 @@ function defaultScoreFn(a) {
 // prop = 'key1.key2'        10ms
 // prop = ['key1', 'key2']   27ms
 function getValue(obj, prop) {
-  var tmp = obj[prop]; if(tmp !== undefined) return tmp
+  var tmp = obj[prop]; if(tmp !== undefined || typeof prop==='symbol') return tmp
   var segs = prop
   if(!Array.isArray(prop)) segs = prop.split('.')
   var len = segs.length

--- a/package.json
+++ b/package.json
@@ -14,10 +14,13 @@
   "main": "fuzzysort.js",
   "scripts": {
     "test": "node test.js",
-    "build": "uglifyjs fuzzysort.js -m -c -o fuzzysort.min.js"
+    "build": "npx uglify-js fuzzysort.js -m -c -o fuzzysort.min.js"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/farzher/fuzzysort.git"
+  },
+  "devDependencies": {
+    "benchmark": "^2.1.4"
   }
 }

--- a/test.js
+++ b/test.js
@@ -191,6 +191,9 @@ async function tests() {
   var results = fuzzysort.go('typography', targets, {keys: ['name']})
   var results = (await fuzzysort.goAsync('typography', targets, {key: 'name'}))
   var results = (await fuzzysort.goAsync('typography', targets, {keys: ['name']}))
+
+  var s = Symbol(), results = fuzzysort.go('va', ['value', ''].map(v=> ({key: v, [s]: fuzzysort.prepare(v)})), {keys: [s]})
+  assert(results.length==1, 'using Symbol as key in prepared field - bug')
 }
 
 


### PR DESCRIPTION
…package.json: updated to include dev-dependencies for test + using npx for build

- fixed #69
- added regression test
- updated package.json to include dev-dependencies + use npx instead of global dependency for build step
- all tests passing with no noticable benchmark diff

> node test # before

    all tests passed
    now benching
    go prepared x 287 ops/sec ±1.06% (37 runs sampled)
    go key x 135 ops/sec ±7.14% (30 runs sampled)
    go keys x 119 ops/sec ±1.98% (33 runs sampled)
    go str x 135 ops/sec ±7.03% (30 runs sampled)
    goAsync x 234 ops/sec ±1.24% (34 runs sampled)
    huge nomatch x 3,445,677 ops/sec ±1.32% (40 runs sampled)
    tricky x 3,930,419 ops/sec ±1.42% (35 runs sampled)
    small x 14,758,100 ops/sec ±1.54% (36 runs sampled)
    somematch x 11,450,607 ops/sec ±1.25% (38 runs sampled)

> node test # after

    all tests passed
    now benching
    go prepared x 271 ops/sec ±3.90% (36 runs sampled)
    go key x 130 ops/sec ±4.12% (32 runs sampled)
    go keys x 107 ops/sec ±3.67% (30 runs sampled)
    go str x 141 ops/sec ±3.05% (32 runs sampled)
    goAsync x 232 ops/sec ±1.42% (35 runs sampled)
    huge nomatch x 3,506,924 ops/sec ±0.71% (39 runs sampled)
    tricky x 3,887,687 ops/sec ±0.71% (35 runs sampled)
    small x 14,701,364 ops/sec ±0.68% (40 runs sampled)
    somematch x 12,073,634 ops/sec ±0.83% (40 runs sampled)
