### PR TITLE
remove unused `firstPossibleI` variable

### DIFF
--- a/fuzzysort.js
+++ b/fuzzysort.js
@@ -329,7 +329,7 @@
 
     var nextBeginningIndexes = prepared._nextBeginningIndexes
     if(nextBeginningIndexes === NULL) nextBeginningIndexes = prepared._nextBeginningIndexes = prepareNextBeginningIndexes(prepared.target)
-    var firstPossibleI = targetI = matchesSimple[0]===0 ? 0 : nextBeginningIndexes[matchesSimple[0]-1]
+    targetI = matchesSimple[0]===0 ? 0 : nextBeginningIndexes[matchesSimple[0]-1]
 
     // Our target string successfully matched all characters in sequence!
     // Let's try a more advanced and strict test to improve the score


### PR DESCRIPTION
In the `algorithmNoTypo()` method this variable is never used.

Similar code exists in the `algorithm()` method, where it is used.

I noticed this after updating Rollup at <https://github.com/qunitjs/qunit>, where it changed the embedding of this library. It found and removed this unused variable.